### PR TITLE
fix: modify status codes in api response

### DIFF
--- a/utils/errorHandler.js
+++ b/utils/errorHandler.js
@@ -4,12 +4,16 @@ function errorHandler(err, req, res, next) {
     statusCode: err.statusCode || 500,
   };
   if (err.name === 'ValidationError') {
+    // check for omitted required fields and set statusCode to 400
+    let errStatusCode = null;
+    if (err.details[0].type === 'string.empty') errStatusCode = 400;
+
     customError.msg = err.errors
       ? Object.values(err.errors)
           .map((item) => item.message)
           .join('.   ')
       : err.details.map((item) => item.message).join('.   ');
-    customError.statusCode = 422;
+    customError.statusCode = errStatusCode ? errStatusCode : 422;
   }
   res.status(customError.statusCode).json({
     msg: customError.msg,


### PR DESCRIPTION
This PR...

## Changes

- the error handler (so that it returns appropriate responses as introduced in #0a536fe and  #aec61a1

## Fixes #48 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
- [x] linter passes
- [x] format check passes
